### PR TITLE
bug fix: initial forced password change issue 

### DIFF
--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -59,6 +59,7 @@ class LoginPage extends React.Component {
         userAttributes.name = userAttributes.email;
         userAttributes.preferred_username = userAttributes.name;
         delete userAttributes.email_verified;
+        delete userAttributes.email;
         this.state.cognitoUser.completeNewPasswordChallenge(this.state.password, userAttributes, {
             onSuccess: (data) => this.passwordChallengeSuccess(data),
             onFailure: err => {


### PR DESCRIPTION
Fix for issue we're seeing where new users are unable to get past the forced password change during their initial login.

I tested this change with the following JS code using node.js:
```
var AmazonCognitoIdentity = require('amazon-cognito-identity-js');

var CognitoUserPool = AmazonCognitoIdentity.CognitoUserPool;
var CognitoUser = AmazonCognitoIdentity.CognitoUser;
var AuthenticationDetails = AmazonCognitoIdentity.AuthenticationDetails;

var poolData = {
    UserPoolId: '<removed>',
    ClientId: '<removed>',
};
var userPool = new CognitoUserPool(poolData);
var userData = {
    Username: '<removed>',
    Pool: userPool,
};
var cognitoUser = new CognitoUser(userData);
var authenticationData = {
    Username: "<removed>",
    Password: "<removed>"
};
var authDetails = new AuthenticationDetails(
    authenticationData
);
   
cognitoUser.authenticateUser(authDetails, {
    onSuccess: () => {
        console.log("user authenticated")
    },
    onFailure: (error) => {
        console.log("authentication failed: " + error)
    },
    newPasswordRequired: function(userAttributes, requiredAttributes) {
        userAttributes.name = userAttributes.email;
        userAttributes.preferred_username = userAttributes.email;
        var newPassword = "<removed>"
        delete userAttributes.email_verified;
        delete userAttributes.email;
        cognitoUser.completeNewPasswordChallenge(newPassword, userAttributes, this);
    },
})
```
Without the line `delete userAttributes.email;` we see the same error using the script as we see in the live site which is the error message `authentication failed: NotAuthorizedException: Cannot modify an already provided email`.  Authentication works fine if we remove the email attribute.

I learned of this fix from this SO post:
https://stackoverflow.com/questions/71667989/aws-cognito-respond-to-new-password-required-challenge-returns-cannot-modify-an